### PR TITLE
Update remotes to CRAN versions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,8 +20,8 @@ Imports:
     Matrix,
     matrixStats,
     purrr,
-    sumstatFactors (>= 0.1.2.319)
+    sumstatFactors (>= 0.1.2.319),
+    ebnm,
+    flashier    
 Remotes: 
-    stephens99/ebnm,
-    willwershcheid/flashier,
     jean997/sumstatFactors


### PR DESCRIPTION
- ebnm package moved from stephens99/ebnm to stephenslab/ebnm (Install fails without this change)
- Both ebnm and flashier are available on cran now so changed to point to CRAN version