### PR TITLE
Fix named argument bug with <-

### DIFF
--- a/R/esmr.R
+++ b/R/esmr.R
@@ -48,7 +48,7 @@ esmr <- function(beta_hat_Y, se_Y,
       warning("Cannot estimate G for network problem yet.\n")
       G <- diag(dat$p)
     }else{
-      G <- estimate_G(beta_hat_X <- dat$Y[,-1,drop =F],
+      G <- estimate_G(beta_hat_X = dat$Y[,-1,drop =F],
                       se_X = dat$S[,-1, drop = F],
                       R = R[-1, -1, drop = FALSE],
                       type = g_type,


### PR DESCRIPTION
`estimate_G` has a named argument `beta_hat_X`. The call to `estimate_G` uses `<-` which does not work as a named argument. It locally assigns a variable `beta_hat_X` rather than using the named argument. The reason it works is that `beta_hat_X <- dat$Y[,-1,drop =F]` silently returns itself when assigned. Since this correctly aligns with the positional argument then it works for this case. This does not cause an actual bug at this point but if `estimate_G` changes named argument order then this will fail.