### PR TITLE
Add faster version of diag(s) %*% X %*% diag(s)

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -106,6 +106,7 @@ check_R <- function(R, tol = 1e-8){
   if(!Matrix::isSymmetric(R)){
     stop("R is not symmetric.\n")
   }
+  stopifnot(is_psd(R, tol))
   evR <- eigen(R, only.values = TRUE)$values
   if(!all(evR > tol)){
     stop("R is not positive definite.\n")
@@ -146,14 +147,14 @@ get_omega <- function(R, S, any_missing){
     omega <- diag(1/s^2)
   }else if(s_equal){
     s <- S[1,]
-    omega <- solve(diag(s) %*% R %*% diag(s))
+    omega <- solve_diag_psd_diag(R, s)
   }else if(R_is_id & !any_missing){
     omega <- apply(S, 1, function(s){
       diag(1/s^2, nrow = p)
     }, simplify = FALSE)
   }else if(!any_missing){
     omega <- apply(S, 1, function(s){
-      solve(diag(s) %*% R %*% diag(s))
+      solve_diag_psd_diag(R, s)
     }, simplify = FALSE)
   }else if(R_is_id){
     S[is.na(S)] <- Inf
@@ -174,7 +175,7 @@ get_omega <- function(R, S, any_missing){
       if(length(ixT) == 0){
         ome <- map(ii, function(j){
           s <- S[j,]
-          solve(diag(s) %*% R %*% diag(s))
+          solve_diag_psd_diag(R, s)
         })
         return(ome)
       }
@@ -183,7 +184,7 @@ get_omega <- function(R, S, any_missing){
       pn <- nrow(myR)
       ome <- map(ii, function(j){
         s <- S[j,-ixT]
-        o <- solve(diag(s, nrow = pn) %*% myR %*% diag(s, nrow = pn))
+        o <- solve_diag_psd_diag(myR, diag(s, nrow = pn))
         om <- z
         om[ixF, ixF] <- o
         om

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -1,0 +1,32 @@
+#' Checks if matrix is positive semi-definite
+#' @param X matrix to test
+#' @param tol tolerance to allow for zero eigenvalues
+is_psd <- function(X, tol = 1e-8) {
+  eigen_vals <- eigen(X, only.values = TRUE)$values
+  # First check is to ensure non-complex eigenvalues
+  return(is.numeric(eigen_vals) &&
+      all(eigen(X, only.values = TRUE)$values > tol))
+}
+
+#' Computes a faster version of a diagonal matrix times a square matrix
+#' times the same diagonal matrix
+#'
+#' @param X square matrix with dimensions d x d
+#' @param s vector of length d
+solve_diag_psd_diag <- function(X, s, check_psd = FALSE) {
+  if (!is.null(dim(s))) s <- diag(s)
+  stopifnot(length(s) == ncol(X))
+  # Same as diag(s) %*% X %*% diag(s)
+  # But ~4x faster
+  # s * X does column-wise multiplication: s * X[, 1], s * X[, 2], ...
+  res <- t(t(s * X) * s)
+
+  # Assume PSD if no check requested
+  is_psd <- ! check_psd || is_psd(res, tol = 0)
+  if (! is_psd) {
+    solve(res)
+  } else {
+    # Assumes PSD
+    chol2inv(chol(res))
+  }
+}


### PR DESCRIPTION
Many of the computations in the omega calculations involve: `solve(diag(s) %*% X %*% diag(s))` where `X` is positive semi-definite. This make a faster version of `diag(s) %*% X %*% diag(s)` as well as replacing `solve` with `chol2inv(chol(...))`.

There are a few other places we could switch `solve` for `chol2inv` in the code as well.

This is about 4x faster for the diag * PSD * diag case:

``` r
library(microbenchmark)

microbenchmark(
  setup = {
    d <- 500
    X <- matrix(
      rnorm(d^2),
      ncol = d,
      nrow = d
    )

    s <- rgamma(d, shape = 3)

    psd_X <- X %*% t(X)
  },
  {
    solve(diag(s) %*% psd_X %*% diag(s))
  },
  {
    base::chol2inv(base::chol(t(t(s * psd_X) * s)))
  }
)

#>                                                     expr       min        lq
#>             {     solve(diag(s) %*% psd_X %*% diag(s)) } 139.08270 141.37686
#>  {     base::chol2inv(base::chol(t(t(s * psd_X) * s))) }  31.02978  31.70065
#>       mean    median        uq       max neval
#>  143.13269 142.73076 144.13562 157.21253   100
#>   32.19331  31.96887  32.68411  34.26854   100
```

Also added just the benchmark for comparing the matrix multiplication comparisons without inverting:

``` r
library(microbenchmark)

microbenchmark(
  setup = {
    d <- 500
    X <- matrix(
      rnorm(d^2),
      ncol = d,
      nrow = d
    )

    s <- rgamma(d, shape = 3)

    psd_X <- X %*% t(X)
  },
  {
    diag(s) %*% psd_X %*% diag(s)
  },
  {
    t(t(s * psd_X) * s)
  }
)
#> Unit: milliseconds
#>                                   expr       min       lq      mean    median
#>  {     diag(s) %*% psd_X %*% diag(s) } 76.425804 77.59049 78.708988 78.287676
#>            {     t(t(s * psd_X) * s) }  1.060178  1.35054  1.906828  1.408678
#>         uq      max neval
#>  79.282233 97.77701   100
#>   1.574113 20.76101   100
```

<sup>Created on 2023-11-17 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>